### PR TITLE
fix #80

### DIFF
--- a/src/pages/Main.tsx
+++ b/src/pages/Main.tsx
@@ -549,8 +549,6 @@ const Intro = ({ scrollYProgress }) => {
     [1.2, 1.2, 2.2 + 1.2 * Math.random(), 10]
   );
   const { innerWidth: screenWidth, innerHeight: screenHeight } = window;
-  const cardWidth = 200 + Math.max(screenWidth - 1200, 0) / 8;
-  const cardHeight = (cardWidth * 3) / 2;
   const centerRandom = (val: number) => Math.random() * val - val / 2;
   const transformValues = (size: number) => {
     const rndValue = centerRandom(size);
@@ -754,9 +752,7 @@ const Intro = ({ scrollYProgress }) => {
           <m.img
             key={i}
             {...prop}
-            width={cardWidth}
-            height={cardHeight}
-            className="fixed -z-10 left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2"
+            className="w-[calc(200px_+_8vw)] h-[calc(300px_+_12vw)] fixed -z-10 left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2"
           ></m.img>
         );
       })}


### PR DESCRIPTION
#80 랜딩페이지 애니매이션 도중 느려지는 이슈

### 문제 상황
#77 화면의 크기에 따라 애니메이션의 전달력이 감소하여 사진크기를 조정하여 문제를 해결함
하지만 확인 과정 중 기기의 사양에 따라 순간적으로 fps가 현격하게 감소하는 현상 확인함

### 코드변경사항
b3e28450cb5fadcd1c04f0b673ca0a92e6d71aa3 
```javascript
// 주요 변경사항
// 전
<m.img
  key={i}
  {...prop}
  className="w-[200px] h-[300px] fixed -z-10 left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2"
></m.img>

//후
const { innerWidth: screenWidth, innerHeight: screenHeight } = window;
const cardWidth = 200 + Math.max(screenWidth - 1200, 0) / 8;
const cardHeight = (cardWidth * 3) / 2;
<m.img
  key={i}
  {...prop}
  width={cardWidth}
  height={cardHeight}
  className="fixed -z-10 left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2"
></m.img>
```

### 해결을 위해 만든 가설
1. #77 을 해결하기 이전부터 해당 문제가 있었는지 명확하지 않음
    -  코드를 되돌려서 바로 확인한 결과 이전에는 없었던 문제임을 확인함
2.  `cardWidth` 에 할당되는 값을 `useRef`에 넣어 컴포넌트가 리랜더링이 되더라도 해당 값은 예외처리가 되도록 설정함
    - 속도 개선이 이뤄지지 않음
3. 애초에 컴포넌트가 리랜더링이 과도하게 발생하여 발생한 문제가 아닐 수도 있음
    - 컴포넌트 내부에 `console.log`를 찍어서 확인하였고 부하가 많이 걸리는 때 리랜더링은 발생하지 않고 있음을 확인
4. `img` 태그의 크기를 `width`, `height` 속성 값으로 제어하는 것과 `css`를 통해 제어하는 것이 gpu 에 어떤 영향을 끼침
    -  크기 제어를 `css`를 통해 하는 것으로 변경하였고 gpu 메모리 값이 치솟는 현상은 해결하였음

### 해결 후 시연
#77 이슈도 잘 해결하면서도 본 이슈 #80 도 해결한 모습 
![animation_troubleshooting_0](https://user-images.githubusercontent.com/59566239/205937175-9c7de8fd-53db-479a-a54c-6931103a4021.gif)
![animation_troubleshooting_0_2](https://user-images.githubusercontent.com/59566239/205937202-4a7b9f96-e631-4398-8555-2d67704a6f07.gif)

### 미 해결 과제
 결국에는 html과 css의 이해도를 요하는 문제였고, 꽤나 많은 자료를 찾아봤지만 우리 상황에 딱 들어맞는 설명을 찾기 쉽지가 않아 아쉽다. 단순히 `img` 태그의 `width`, `height` 속성과 `css`의 `width`, `height`의 차이점을 설명하는 글은 많은데 그래서 animation이 실행 되는 때에는 어떻게 다른지 언급하는 글은 찾기가 쉽지 않다. 시간을 두고 공부해보면 좋은 주제인 것 같다.
