### PR TITLE
95 usepopup callbacknotfire

### DIFF
--- a/src/hooks/useTicketPop.tsx
+++ b/src/hooks/useTicketPop.tsx
@@ -94,6 +94,9 @@ const useTicket = (
     });
     const handleClickModalBack = () => {
       setIsPoped(false);
+      if (getAfterToasted) {
+        getAfterToasted();
+      }
     };
     const handleAnimationEnd = () => {
       if (getToastOnly) {

--- a/src/hooks/useTicketPop.tsx
+++ b/src/hooks/useTicketPop.tsx
@@ -91,6 +91,9 @@ const useTicket = (
   const Ticket = () => {
     useWindowKeyboard("Escape", () => {
       setIsPoped(false);
+      if (getAfterToasted) {
+        getAfterToasted();
+      }
     });
     const handleClickModalBack = () => {
       setIsPoped(false);


### PR DESCRIPTION
esc키 누를때 모달 배경을 클릭할때 모두 콜백함수가 작동하도록 변경했습니다.

```typescript
    useWindowKeyboard("Escape", () => {
      setIsPoped(false);
      if (getAfterToasted) {
        getAfterToasted();
      }
    });
    const handleClickModalBack = () => {
      setIsPoped(false);
      if (getAfterToasted) {
        getAfterToasted();
      }
    };
```